### PR TITLE
Deprecate `DisableScrollZoom` query string

### DIFF
--- a/pages/integration--query-string-parameters.md
+++ b/pages/integration--query-string-parameters.md
@@ -49,13 +49,6 @@ http://catalogs.company.com/Brochure/?Page=15
 {% include note.html content="Linking to a non-existing page number will take the user to the first page instead." %}
 
 
-## DisableScrollZoom
-Using this setting you can disable zooming when users use their mouse wheel for scrolling:
-```
-http://catalogs.company.com/Brochure/?DisableScrollZoom=true
-```
-{% include note.html content="This will not affect Flash & mobile catalogs." %}
-
 ## Affiliate_
 
 The Affiliate_ parameter that can be used for tracking ex. referrals. All query parameters starting with Affiliate_ will be appended to any external URL the iPaper contacts.


### PR DESCRIPTION
This commit removes the documentation for the `DisableScrollZoom` query string support, as we have already announced publicly that support for scroll-to-zoom feature to be deprecated and be replaced by scroll-to-pan functionality.

This PR should only be merged once IP-7070 is deployed.