### PR TITLE
Added documentation on how to resolve occasional layout issues on iOS Safari with popup frames

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,7 +245,6 @@ GEM
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unicode-display_width (1.4.0)
-    wdm (0.1.1)
 
 PLATFORMS
   ruby
@@ -254,7 +253,6 @@ PLATFORMS
 
 DEPENDENCIES
   github-pages
-  wdm (>= 0.1.0)
 
 BUNDLED WITH
    1.16.6

--- a/pages/integration--popup-frame.md
+++ b/pages/integration--popup-frame.md
@@ -39,6 +39,14 @@ parent.postMessage({
 }, '*');
 ```
 
+## Workarounds for occasional incorrect rendering on iOS browsers
+
+Due to the way how iOS browsers (iOS Safari and any other third-party browsers, since they all use the WebKit rendering engine) renders iframe elements, there is a possibility that certain pages, when embedded within an iframe and viewed on iOS browsers, will appear too large and hence overflow from its original bounds.
+
+In iOS browsers, iframe elements cannot be restricted by size: declaring explicit width and height in CSS does not work. The browser will instead attempt to size the iframe so that all its content becomes visible. This has proven to be problematic for a small subset of pages, especially those containing wide content that are dynamically resized by JavaScript.
+
+We recommend adding `max-width: 100vw` to the body element of the embedded page, which will force the iframed page to be aware of the size of its wrapping container. It effectively places a constraint on the maximum permissible width for the page.
+
 ## See also
 
 [OWASP Guide to Clickjacking defense](https://www.owasp.org/index.php/Clickjacking_Defense_Cheat_Sheet)

--- a/pages/integration--popup-frame.md
+++ b/pages/integration--popup-frame.md
@@ -41,11 +41,11 @@ parent.postMessage({
 
 ## Workarounds for occasional incorrect rendering on iOS browsers
 
-Due to the way how iOS browsers (iOS Safari and any other third-party browsers, since they all use the WebKit rendering engine) renders iframe elements, there is a possibility that certain pages, when embedded within an iframe and viewed on iOS browsers, will appear too large and hence overflow from its original bounds.
+Due to the way how iOS browsers (iOS Safari and any other third-party browsers, since they all use the WebKit rendering engine) renders `<iframe>` elements, there is a possibility that certain pages, when embedded within an `<iframe>` and viewed on iOS browsers, will appear too large and hence overflow from its original bounds.
 
-In iOS browsers, iframe elements cannot be restricted by size: declaring explicit width and height in CSS does not work. The browser will instead attempt to size the iframe so that all its content becomes visible. This has proven to be problematic for a small subset of pages, especially those containing wide content that are dynamically resized by JavaScript.
+In iOS browsers, `<iframe>` elements cannot be restricted by size: declaring explicit width and height in CSS does not work. The browser will instead attempt to size the `<iframe>` so that all its content becomes visible. This has proven to be problematic for a small subset of pages, especially those containing wide content that are dynamically resized by JavaScript.
 
-We recommend adding `max-width: 100vw` to the body element of the embedded page, which will force the iframed page to be aware of the size of its wrapping container. It effectively places a constraint on the maximum permissible width for the page.
+We recommend adding `max-width: 100vw` to the body element of the embedded page, which will force the `<iframe>` to be aware of the size of its wrapping container. It effectively places a constraint on the maximum permissible width for the page.
 
 ## See also
 


### PR DESCRIPTION
We have had several support tickets involving embedded webpages rendering beyond their pre-allocated widths in popup frame in the Viewer. It all boils down to how `<iframe>` elements are rendered on iOS browsers.

After talking to CC we decided that having this behavior and its solution documented will be helpful to our customers, so here it is :) 

See: https://secure.helpscout.net/conversation/707067577/41042?folderId=1708371