### PR TITLE
Fixed minor typos in iPaper JS API documentation

### DIFF
--- a/pages/javascript-api--advanced-usage.md
+++ b/pages/javascript-api--advanced-usage.md
@@ -20,7 +20,7 @@ The minimal config design of our API means that it will attempt to look for an `
     {% include warning.html content="If `data-ipaper` attribute is not added, then the default API instance will simply select the **first** `<iframe>` containing a flipbook that reports back, presenting a race condition. **We cannot guarantee that this is always the first visible flipbook on the page.**" %}
 
 
-2. **Instantiate APIs for subsequent flipbooks.** Subsequent flipbooks will need to added to manually instantiated API constructor manually. The API constructor is exposed via the `_iPaperAPI` (note the preceeding underscore character), and a new instance can be created on an `<iframe>` element by passing the element as the first argument:
+2. **Instantiate APIs for subsequent flipbooks.** Subsequent flipbooks will need to have their APIs manually instantiated. The constructor is exposed via the `_iPaperAPI` (note the preceeding underscore character), and a new instance can be created on an `<iframe>` element by passing the element as the first argument:
 
     ```js
     var anotherIPaper = document.getElementById('another-flipbook')
@@ -36,7 +36,7 @@ The minimal config design of our API means that it will attempt to look for an `
     <title>Multiple iframed iPapers</title>
 
     <!-- Start of async iPaper API code -->
-    <!-- NOTE: The entire code snippet below can be obtained directly from the Admin. Refer to our help article for further information -->
+    <!-- NOTE: The entire code snippet below can be obtained directly from the Admin. Refer to our help article for further information. -->
     <script>
     (function(i,P,a,p,e,r){if(i.getElementById(a=a+'-'+e))return;
     r=i.querySelector(P).parentNode.appendChild(i.createElement(P));
@@ -89,7 +89,7 @@ The event name that the event listeners should check with are specified in [even
     <title>Example iPaper JS API use</title>
 
     <!-- Start of async iPaper API code -->
-    <!-- NOTE: The entire code snippet below can be obtained directly from the Admin. Refer to our help article for further information -->
+    <!-- NOTE: The entire code snippet below can be obtained directly from the Admin. Refer to our help article for further information. -->
     <script>
     (function(i,P,a,p,e,r){if(i.getElementById(a=a+'-'+e))return;
     r=i.querySelector(P).parentNode.appendChild(i.createElement(P));

--- a/pages/javascript-api--quick-start.md
+++ b/pages/javascript-api--quick-start.md
@@ -27,7 +27,7 @@ r.id=a;r.async=1;r.src=p+'/'+e+'.js'})
 
 ## Minimal config setup
 
-Most of our customers use our API to interact with a single instance of a flipbook on their page. A frictionless, minimal config setup is therefore implemented&mdash;meaning that for use-cases of single flipbooks iframed on a single page, no additional configuation or markup changes are required. The setup will automatically identify the first iframed flipbook on the page, which can have a minimal markup as such:
+Most of our customers use our API to interact with a single instance of a flipbook on their page. A frictionless, minimal config setup is therefore implemented&mdash;meaning that for use-cases involving single flipbooks iframed on a single page, no additional configuation or markup changes are required. The setup will automatically identify the first iframed flipbook on the page, which can have a minimal markup as such:
 
 ```html
 <iframe src="https://demo.ipaper.io"></iframe>
@@ -46,7 +46,7 @@ The embedded script will call the `iPaperInit()` method that is defined globally
     <title>Example iPaper JS API use</title>
 
     <!-- Start of async iPaper API code -->
-    <!-- NOTE: The entire code snippet below can be obtained directly from the Admin. Refer to our help article for further information -->
+    <!-- NOTE: The entire code snippet below can be obtained directly from the Admin. Refer to our help article for further information. -->
     <script>
     (function(i,P,a,p,e,r){if(i.getElementById(a=a+'-'+e))return;
     r=i.querySelector(P).parentNode.appendChild(i.createElement(P));
@@ -79,9 +79,9 @@ The embedded script will call the `iPaperInit()` method that is defined globally
 
 The `iPaperAPI` object exposes several methods that can be grouped into two categories: [**magic event callbacks**](./events) and [**magic commands**](./commands).
 
-- **Events happen on the flipbook and are emitted to the parent window**, which triggers magic callbacks. An example of a flipbook event is the [`onSpreadChange`](./events#onspreadchange) event. [Read more](./events) about how to listen to these events and react to them accordingly.
+- **Events happen on the flipbook and are emitted to the parent window**, which trigger magic callbacks. An example of a flipbook event is the [`onSpreadChange`](./events#onspreadchange) event. [Read more](./events) about how to listen to these events and react to them accordingly.
 - **Commands are instructions issued from the parent window to the flipbook**, done via invoking magic commands. An example of a flipbook command is the [`goToPage`](./commands#gotopage) method. [Read more](./commands) about how to issue commands to instruct your iframed flipbook to perform specified actions.
 
 ## Multiple flipbooks
 
-In the event that multiple flipbooks are to be embedded via `<iframe>` on the same page, some additional configurations are required. Refer to the [**Multiple Flipbooks**](./advanced-usage#multiple-flipbooks) section for further implementation details.
+In the event that multiple flipbooks are to be embedded via `<iframe>` on the same page, some additional configuration is required. Refer to the [**Multiple Flipbooks**](./advanced-usage#multiple-flipbooks) section for further implementation details.


### PR DESCRIPTION
I found some minor typos when going through the iPaper JS API. Fixed them for good.