### PR TITLE
Added "PDF Download" as new event being tracked via Google Analytics

### DIFF
--- a/pages/integration--events-tracked-by-google-analytics-and-tag-manager.md
+++ b/pages/integration--events-tracked-by-google-analytics-and-tag-manager.md
@@ -15,8 +15,9 @@ We'll also track various **Events** across our flipbooks. Take a look at the lis
 > **NOTE:** All events are tracked to the **iPaper events** category
 
 | Action | Label | Comment |
-| ------------- | ------------- | -- |
+| ------ | ----- | ------- |
 | External Link Click | HoverText: {linkHoverText} \| Url: {externalUrl} \| Page: {pageNumber} |
+| PDF Download | n.a. | n.a. |
 | Popup Image Click | HoverText: {linkHoverText} \| Url: {imageUrl} \| Page: {pageNumber} |
 | Popup Image Gallery Click | HoverText: {linkHoverText} \| Page: {pageNumber} |
 | Popup Content Click | HoverText: {linkHoverText} \| Page: {pageNumber} |


### PR DESCRIPTION
As of IP-7690, we are now tracking PDF Downloads via Google Analytics. This new event should be added in our technical docs.