### PR TITLE
Update documentation on external JSON shop links

### DIFF
--- a/_data/sidebar.yml
+++ b/_data/sidebar.yml
@@ -155,7 +155,7 @@ entries:
     - title: Custom Domain
       url: /integration/custom-domain
 
-    - title: Embedding Flipbooks inside iOS and Android apps
+    - title: Embedding flipbooks inside iOS and Android apps
       url: /integration/embedding-flipbooks-inside-ios-and-android-apps
 
     - title: Form Integration

--- a/pages/integration--embedding-flipbook-inside-ios-and-android-apps.md
+++ b/pages/integration--embedding-flipbook-inside-ios-and-android-apps.md
@@ -1,40 +1,43 @@
 ---
-title: Embedding iPapers Inside iOS and Android App
+title: Embedding flipbooks inside iOS and Android App
 permalink: /integration/embedding-flipbooks-inside-ios-and-android-apps
 redirect_from: "/display/DOC/Embedding+iPapers+Inside+iOS+and+Android+Applications"
 ---
 
 {% include important.html content="
-	If you in any way exploit a quirk of our system to your benefit then we CANNOT guarantee that iPaper will continue to work as you would expect. If you feel the need to make any kind of workaround to achieve your desired behavior, make sure you validate it with us first. Otherwise you risk your app breaking at some point when we update our system.<br>
-	<br>
+	If you in any way exploit a quirk of our system to your benefit then we cannot guarantee that our flipbooks will continue to work as you would expect. If you feel the need to make any kind of workaround to achieve your desired behavior, make sure you validate it with us first. Otherwise you risk your app breaking at some point when we update our system.
+	<br />
+	<br />
 	If you get in contact with us first, we'll do all we can to help you out and ensure a long term viable solution is made.
 "%}
 
-## Embedding the Flipbook
+## Embedding the flipbook
 
-iPaper will automatically detect which device is trying to access any given catalog and display corresponding view. Whether that be the iPad, iPhone or Android views for handheld devices.
-You should always link directly to a catalog of the form:
+iPaper will automatically detect which device is trying to access any given flipbook and display corresponding view. Whether that be the iPad, iPhone or Android views for handheld devices.
+
+You should always link directly to a flipbook of the form:
 
 ```
 http://partner.ipapercms.dk/Firma/Tilbudsavis/
 ```
 
-{% include important.html content="It is VERY important that you never link directly to any files/subdirectories beneath the flipbook - only the main flipbook url can be trusted to be static."%}
+{% include important.html content="It is very important that you never link directly to any files/subdirectories beneath the flipbook - only the main flipbook url can be trusted to be static."%}
 
-## Important Query String Parameter When Embedding the Catalog
+## Important query string parameter when embedding the flipbook
 
 For some mobile devices, we can't detect whether the navigation bar is present or not. As a result, content may either be shown too small, or cropped, in such cases.
+
 To avoid this, you should hard code the browser height and send it to us in the query string like so:
 
 ```
-http://partner.ipapercms.dk/Firma/tilbudsavis/?EmbeddedHeight=X
+http://partner.ipapercms.dk/Firma/tilbudsavis/?EmbeddedHeight=x
 ```
 
-In the example above we will force our content to be exactly X pixels high, circumventing our normal size calculations.
+In the example above we will force our content to be exactly `x` pixels high, circumventing our normal size calculations.
 {% include note.html content="Make sure that the EmbeddedHeight value is an integer with no decimals."%}
-{% include important.html content="Unfortunately it is not possible to dynamically resize the embedded Flipbook when using the EmbeddedHeight parameter. As such, you'll have to resize the container and reload the catalog with a new EmbeddedHeight value appended."%}
+{% include important.html content="Unfortunately it is not possible to dynamically resize the embedded flipbook when using the EmbeddedHeight parameter. As such, you'll have to resize the container and reload the catalog with a new EmbeddedHeight value appended."%}
 
-### Calculating the EmbeddedHeight Value on iOS Devices
+### Calculating the EmbeddedHeight value on iOS devices
 
 On iOS, you can calculate the EmbeddedHeight value of a given UIWebView like this:
 
@@ -43,7 +46,7 @@ CGRect webViewSize = [_webView bounds];
 int embeddedHeight = (int)webViewSize.size.height;
 ```
 
-### Calculating the EmbeddedHeight Value on Android Devices
+### Calculating the EmbeddedHeight value on Android devices
 
 On Android you can calculate the EmbeddedHeight value of a given WebView like this:
 

--- a/pages/integration--embedding-flipbook-inside-ios-and-android-apps.md
+++ b/pages/integration--embedding-flipbook-inside-ios-and-android-apps.md
@@ -54,27 +54,49 @@ int embeddedHeight = (int)webViewSize.size.height;
 
 ## Shop Integration
 
-When embedding an iPaper inside an iOS/Android application it is not possible to use our normal JavaScript API, as this requires the page to be iframed. As an alternative it is possible to override the normal behavior of shop links and force them to open a specially formed URL, enabling you to intercept the call and thus be notified of users clicking on shop links.
+When embedding a flipbook inside an iOS/Android application it is not possible to use our normal JavaScript API, as this requires the flipbook to be iframed. As an alternative it is possible to override the normal behavior of shop links and force them to open a specially formed URL, enabling you to intercept the call and thus be notified of users clicking on shop links.
 
-To force the special shop link functionality, you'll have to add a special query string parameter to the iPaper URL. If the normal iPaper address is this:
+To force the special shop link functionality, you'll have to add a special query string parameter to the flipbook URL. If the normal flipbook URL is this:
 
 ```
-http://ipaper.ipapercms.dk/Client/MyCatalog/
+http://ipaper.ipapercms.dk/client/MyCustomFlipbook/
 ```
 
 The embedded URL should be this, to invoke the special shop link handling:
 
 ```
-http://ipaper.ipapercms.dk/Client/MyCatalog/?ExternalJsonShopLinks=True
+http://ipaper.ipapercms.dk/client/MyCustomFlipbook/?ExternalJsonShopLinks=True
 ```
 
 Once the `ExternalJsonShopLinks` parameter has been enabled, clicking on a shop link will then navigate the user to the following URL, containing a JSON object with all of the product details:
 
-```json
-ipapershop: { name: "Milk", description: "Half gallon", price: 25.95, productID: "M-926" }
+```
+ipapershop://<payload>
 ```
 
-If a link property has not been defined in the backend, it will not be included in the JSON object. Thus, if only the name and price has been entered for a product, the description and productID properties won't be included in the JSON object.
+| Property      | Type     | Description                                |
+| ------------- | -------- | ------------------------------------------ |
+| `title`       | `string` | Shop item title                            |
+| `description` | `string` | Shop item description                      |
+| `productId`   | `string` | Shop item product ID                       |
+| `price`       | `number` | Shop item price                            |
+| `originPage`  | `number` | Page number where the shop item is located |
+| `quantity`    | `number` | Number of items added                      |
+| `packageSize` | `number` | Number of items per package                |
 
-{% include note.html content="This functionality is only applicable to the mobile versions, and setting the `ExternalJsonShopLinks` parameter thus has no impact on the normal desktop (Flash) version of the iPaper catalog."%}
+An example of the emitted JSON is as follow:
+
+```json
+ipapershop: {
+	title: "Milk",
+	description: "Half gallon",
+	productId: "M-926",
+	price: 25.95,
+	originPage: 4,
+	quantity: 2,
+	packageSize: 1
+}
+```
+
+{% include note.html content="This functionality is only applicable to the mobile versions, and setting the `ExternalJsonShopLinks` parameter thus has no impact on the normal desktop version of the flipbook."%}
 


### PR DESCRIPTION
This commit ties in with the changes made in IP-8127.

Based on our technical documentation, we should support redirecting to a custom `ipapershop://<payload>` URL if the `externalJsonShopLinks=true` query string is present. However, this feature seems to have been lost over time, and today we have a customer that requires that kind of support.

This feature is required when using flipbooks in native iOS/Android apps, because they cannot use the JavaScript API for iframed flipbooks.

I've checked with Mark, and the UX should be as follows, if the query string is present:

1. We intercept all add to basket features, so that the shop basket is not updated. We instead bypass it completely.

2. We emit the shop item in a URL-safe JSON payload in the form of `ipapershop://<payload>`
I have made the decision to not coerce values to undefined or null if they are falsy. Instead, we simply follow the same data structure we emit for our JS API, such that values are emitted "as-is", for example: if there is no description provided, we do not coerce it to undefined or null. Instead, we just emit an empty string, just like we always do. This is so that the output is unified across all of our outward facing APIs.

The payload is finalized as such:

```
{
  title: string,
  description: string,
  price: number,
  productId: string,
  packageSize: number,
  quantity: number,
  originPage: number,
}
```

The new properties are packageSize, quantity, and originPage, added to be consistent with the output of our JS API's `onItemAdd` event.