### PR TITLE
Update documentation for Display JS API events

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -240,7 +240,6 @@ GEM
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
     unicode-display_width (1.6.1)
-    wdm (0.1.1)
     zeitwerk (2.2.2)
 
 PLATFORMS
@@ -249,7 +248,6 @@ PLATFORMS
 
 DEPENDENCIES
   github-pages
-  wdm (>= 0.1.0)
 
 BUNDLED WITH
    2.1.4

--- a/pages/display-javascript-api--events.md
+++ b/pages/display-javascript-api--events.md
@@ -6,7 +6,7 @@ summary: Display JavaScript API emits custom events that can be listened to on t
 
 ## Overview
 
-The Display JavaScript API emits custom events to the document root so that you can keep track of changes to the Display API instance.
+The Display JavaScript API emits custom events to the document root so that you can keep track of changes to the Display API instance. Due to the nature of the UI/UX of Display, these events are only relevant if your user is originating from a desktop or tablet device. Mobile devices are redirected to the actual URL of the Display, where interaction with the API is not possible.
 
 ### `iPaperDisplayApiReady`
 
@@ -14,7 +14,17 @@ This event is emitted when the Display JavaScript API has successfully instantia
 
 ```js
 document.addEventListener('iPaperDisplayApiReady', function () {
-    // At the point in time, window.iPaperDisplayApi is available in the global scope
+    // At this point in time, window.iPaperDisplayApi is available in the global scope
     window.iPaperDisplayApi.show();
+});
+```
+
+### `iPaperDisplayInstanceReady`
+
+This event is emitted when the Display JavaScript API has successfully loaded a Display instance and the instsance is now visible and ready to be interacted with. At this point, the user should be able to interact (scroll, click, etc.) with the Display instance shown on the side.
+
+```js
+document.addEventListener('iPaperDisplayInstanceReady', function () {
+    // At this point in time, the Display Instance is ready to be interacted with
 });
 ```

--- a/pages/display-javascript-api--events.md
+++ b/pages/display-javascript-api--events.md
@@ -6,7 +6,7 @@ summary: Display JavaScript API emits custom events that can be listened to on t
 
 ## Overview
 
-The Display JavaScript API emits custom events to the document root so that you can keep track of changes to the Display API instance. Due to the nature of the UI/UX of Display, these events are only relevant if your user is originating from a desktop or tablet device. Mobile devices are redirected to the actual URL of the Display, where interaction with the API is not possible.
+The Display JavaScript API emits custom events to the document root so that you can keep track of changes to the Display API instance.
 
 ### `iPaperDisplayApiReady`
 
@@ -28,3 +28,5 @@ document.addEventListener('iPaperDisplayInstanceReady', function () {
     // At this point in time, the Display Instance is ready to be interacted with
 });
 ```
+
+{% include note.html content="Due to the nature of the UI/UX of Display, the <code>iPaperDisplayInstanceReady</code> event is only fired if your user is originating from a desktop or tablet device. Mobile devices are redirected to the actual URL of the Display, where interaction with the API is not possible." %}


### PR DESCRIPTION
This is due to the addition of a new event `iPaperDisplayInstanceReady` event, and fixes done to ensure that `iPaperDisplayApiReady` does what we say it actually does.

See IP-8722 for more details.