### PR TITLE
Update query string documentation for support for `GoToAndHighlightFirstSearchResult`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -240,7 +240,6 @@ GEM
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
     unicode-display_width (1.6.1)
-    wdm (0.1.1)
     zeitwerk (2.2.2)
 
 PLATFORMS
@@ -249,7 +248,6 @@ PLATFORMS
 
 DEPENDENCIES
   github-pages
-  wdm (>= 0.1.0)
 
 BUNDLED WITH
    2.1.4

--- a/css/customstyles.css
+++ b/css/customstyles.css
@@ -1046,10 +1046,6 @@ a code {
     color: #248EC2;
 }
 
-code + a > code {
-    margin-left: -7px;
-}
-
 table th code {
     color: white;
 }

--- a/css/lavish-bootstrap.css
+++ b/css/lavish-bootstrap.css
@@ -4336,6 +4336,9 @@ a.thumbnail:focus {
 .alert .alert-link {
   font-weight: bold;
 }
+.alert a {
+  color: inherit;
+}
 .alert > p,
 .alert > ul {
   margin-bottom: 0;

--- a/pages/integration--query-string-parameters.md
+++ b/pages/integration--query-string-parameters.md
@@ -15,13 +15,25 @@ http://catalogs.company.com/Brochure/?ForceLanguage=fr
 {% include note.html content="Please refer to iPaper Support if you need a specific language code. If you link to a non-existing language code, the catalog default will be used instead." %}
 
 
-## GotoFirstSearchResult
+## GoToFirstSearchResult
 
-If you don't want to link to a specific page number, but rather to the first page that contains a certain search term, the GotoFirstSearchResult parameter can be used. The following sample link would take the user to the first page containing the term "Century":
+If you do not want to link to a specific page number, but rather to the first page that contains a certain search term, the GoToFirstSearchResult parameter can be used. The following sample link would take the user to the first page containing the term "Century":
 ```
-http://catalogs.company.com/Brochure/?GotoFirstSearchResult=Century
+http://catalogs.company.com/Brochure/?GoToFirstSearchResult=Century
 ```
 {% include note.html content="If the search term is not found, the user will be sent to the first page." %}
+
+{% include warning.html content="If both `GoToFirstSearchResult` and [`GoToAndHighlightFirstSearchResult`](#gotoandhighlightfirstsearchresult) are specified in the URL, this query string value will be ignored." %}
+
+## GoToAndHighlightFirstSearchResult
+
+This query performs the same operation as [`GoToFirstSearchResult`](#gotofirstsearchresult) above, but has the additional ability to highlight the term on the page itself.
+
+```
+http://catalogs.company.com/Brochure/?GoToAndHighlightFirstSearchResult=Century
+```
+
+{% include note.html content="If both [`GoToFirstSearchResult`](#gotofirstsearchresult) and `GoToAndHighlightFirstSearchResult` are specified in the URL, this query string value will take precedence." %}
 
 ## HideNavigationBars
 


### PR DESCRIPTION
**DO NOT MERGE until IP-8785 has been deployed!**

This PR is necessary to document the newly added query string key `GoToAndHighlightFirstSearchResult`, introduced in IP-8785.