### PR TITLE
Added fullscreen API documentation for iframed flipbooks

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    activesupport (6.0.2.1)
+    activesupport (6.0.2.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -16,7 +16,7 @@ GEM
     colorator (1.1.0)
     commonmarker (0.17.13)
       ruby-enum (~> 0.5)
-    concurrent-ruby (1.1.5)
+    concurrent-ruby (1.1.6)
     dnsruby (1.61.3)
       addressable (~> 2.5)
     em-websocket (0.5.1)
@@ -27,10 +27,10 @@ GEM
     eventmachine (1.2.7)
     eventmachine (1.2.7-x64-mingw32)
     execjs (2.7.0)
-    faraday (1.0.0)
+    faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
-    ffi (1.12.1)
-    ffi (1.12.1-x64-mingw32)
+    ffi (1.12.2)
+    ffi (1.12.2-x64-mingw32)
     forwardable-extended (2.6.0)
     gemoji (3.0.1)
     github-pages (204)
@@ -210,7 +210,7 @@ GEM
       mini_portile2 (~> 2.4.0)
     nokogiri (1.10.8-x64-mingw32)
       mini_portile2 (~> 2.4.0)
-    octokit (4.15.0)
+    octokit (4.18.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
     pathutil (0.16.2)
@@ -220,9 +220,9 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rouge (3.13.0)
-    ruby-enum (0.7.2)
+    ruby-enum (0.8.0)
       i18n
-    rubyzip (2.1.0)
+    rubyzip (2.3.0)
     safe_yaml (1.0.5)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
@@ -237,11 +237,10 @@ GEM
     thread_safe (0.3.6)
     typhoeus (1.3.1)
       ethon (>= 0.9.0)
-    tzinfo (1.2.6)
+    tzinfo (1.2.7)
       thread_safe (~> 0.1)
-    unicode-display_width (1.6.1)
-    wdm (0.1.1)
-    zeitwerk (2.2.2)
+    unicode-display_width (1.7.0)
+    zeitwerk (2.3.0)
 
 PLATFORMS
   ruby
@@ -249,7 +248,6 @@ PLATFORMS
 
 DEPENDENCIES
   github-pages
-  wdm (>= 0.1.0)
 
 BUNDLED WITH
    2.1.4

--- a/pages/integration--iframing-flipbooks.md
+++ b/pages/integration--iframing-flipbooks.md
@@ -61,7 +61,15 @@ In order to iframe a iPaper catalog, spanning 100% of page, we need to use a spe
   </head>
     <body style="height: 100%">
         <div style="height: 100%; width: 100%; overflow: hidden">
-            <iframe src="http://test.ipapercms.dk/Releases/Mobile/" scrolling="no" frameborder="0" style="width: 100%; height: 100%"></iframe>
+            <iframe
+                src="http://test.ipapercms.dk/Releases/Mobile/"
+                scrolling="no"
+                frameborder="0"
+                style="width: 100%; height: 100%"
+                allow="fullscreen"
+                allowfullscreen
+                webkitallowfullscreen
+                mozallowfullscreen></iframe>
         </div>
     </body>
 </html>
@@ -86,11 +94,28 @@ For these platforms you can specify width in any size you want, even in percenta
   </head>
     <body style="height: 100%">
         <div style="height: 300px; width: 600px; overflow: hidden">
-            <iframe src="http://test.ipapercms.dk/Releases/Mobile/" scrolling="no" frameborder="0" style="width: 100%; height: 100%"></iframe>
+            <iframe
+                src="http://test.ipapercms.dk/Releases/Mobile/"
+                scrolling="no"
+                frameborder="0"
+                style="width: 100%; height: 100%"
+                allow="fullscreen"
+                allowfullscreen
+                webkitallowfullscreen
+                mozallowfullscreen></iframe>
         </div>
     </body>
 </html>
 ```
+
+## Allow fullscreen API access
+
+In order to allow elements in the flipbook to have access to the fullscreen API (e.g. embedded videos from Vimeo/YouTube or native MP4 videos) when the flipbook itself is iframed, the `<iframe>` element needs to allow it explicitly. This is done by adding the following attributes to the element:
+
+* `allow="fullscreen"`
+* `allowfullscreen` (for backwards compatbility)
+* `webkitallowfullscreen` (for backwards compatbility)
+* `mozallowfullscreen` (for backwards compatbility)
 
 ### Dynamically Resizing
 Dynamically resizing the div will work. Do make sure you resize the outer and not the iframe.


### PR DESCRIPTION
Right now, our iframing flipbook instructions do not include `allow="fullscreen"` support. That should be added so that embedded videos can go fullscreen in iframed flipbooks.